### PR TITLE
test(profile): add validation coverage and profile prefs e2e

### DIFF
--- a/Sprints/ContributionLog/contribution-log-ammar.md
+++ b/Sprints/ContributionLog/contribution-log-ammar.md
@@ -15,7 +15,10 @@
 
 | Date | Task | Description | Time Spent |
 |------|------|-------------|------------|
-| 2026-01-30 | Example of Task | description of task | time spent |
-| 2026-01-30 | Example of Task | description of task | time spent |
-| 2026-01-30 | | | |
-| 2026-01-30 | | | |
+| 2026-02-13 | Test Updates | Rewrote user registration and login test cases for the new BetterAuth implementation | 2h |
+| 2026-02-14 | Testing | Added unit tests for profile management user story and added integration tests | 2h |
+| 2026-02-17 | Sprint Planning | Created sprint 2 backlog plan with all user stories and tasks | 1.5h |
+| 2026-02-20 | Issue Tracking | Created GitHub issues for all acceptance tests and user stories for sprint 2 | 1.5h |
+| 2026-02-26 | Merge & Conflict Resolution | Merged all features to main and resolved merge conflicts | 3h |
+
+**Total Time:** 10h

--- a/backend/src/controllers/auth.controller.ts
+++ b/backend/src/controllers/auth.controller.ts
@@ -4,6 +4,7 @@ import { updateUserProfile } from "../services/auth.service.js";
 import { UpdateProfileInput } from "../types/index.js";
 import { AuthenticatedRequest } from "../middleware/auth.middleware.js";
 import { getAuth } from "../lib/auth.js";
+import { sanitizeProfileUpdate } from "../utils/profile.js";
 
 export async function setPassword(
   req: Request,
@@ -44,7 +45,13 @@ export async function updateProfile(
 ): Promise<void> {
   try {
     const { session } = req as AuthenticatedRequest;
-    const profileData = req.body as Omit<UpdateProfileInput, "userId">;
+    const rawProfileData = req.body as Omit<UpdateProfileInput, "userId"> & {
+      userId?: string;
+    };
+    const profileData = sanitizeProfileUpdate(rawProfileData) as Omit<
+      UpdateProfileInput,
+      "userId"
+    >;
 
     console.log("updateProfile request - userId:", session.user.id, "fields:", Object.keys(profileData));
 

--- a/backend/src/utils/profile.ts
+++ b/backend/src/utils/profile.ts
@@ -1,0 +1,103 @@
+import { dietaryOptions } from "@masterchef/shared/constants";
+import { ApiError } from "../types/index.js";
+
+const dietaryLookup = new Map(
+  dietaryOptions.map((option) => [option.toLowerCase(), option]),
+);
+
+function makeError(message: string, statusCode = 400): ApiError {
+  const error: ApiError = new Error(message);
+  error.statusCode = statusCode;
+  return error;
+}
+
+function toList(input: unknown, label: string): string[] {
+  if (input == null) return [];
+  if (Array.isArray(input)) {
+    return input.map((v) => String(v));
+  }
+  if (typeof input === "string") {
+    return input.split(",");
+  }
+  throw makeError(`${label} must be an array or comma-separated string`, 400);
+}
+
+export function normalizeDietaryRestrictions(
+  input: unknown,
+): string[] | undefined {
+  if (input == null) return undefined;
+  const values = toList(input, "Dietary restrictions");
+  const cleaned: string[] = [];
+  const invalid: string[] = [];
+  const seen = new Set<string>();
+
+  for (const raw of values) {
+    const trimmed = String(raw).trim();
+    if (!trimmed) continue;
+    const canonical = dietaryLookup.get(trimmed.toLowerCase());
+    if (!canonical) {
+      invalid.push(trimmed);
+      continue;
+    }
+    const key = canonical.toLowerCase();
+    if (!seen.has(key)) {
+      seen.add(key);
+      cleaned.push(canonical);
+    }
+  }
+
+  if (invalid.length) {
+    throw makeError(`Invalid dietary options: ${invalid.join(", ")}`, 400);
+  }
+
+  return cleaned;
+}
+
+export function sanitizeAllergies(input: unknown): string[] | undefined {
+  if (input == null) return undefined;
+  const values = toList(input, "Allergies");
+  const cleaned: string[] = [];
+  const seen = new Set<string>();
+
+  for (const raw of values) {
+    let value = String(raw).trim();
+    if (!value) continue;
+    value = value.replace(/[\u0000-\u001f\u007f]/g, "");
+    value = value.replace(/[<>]/g, "");
+    value = value.replace(/\s+/g, " ");
+    value = value.replace(/[^a-zA-Z0-9 \-']/g, "");
+    value = value.trim();
+    if (!value) continue;
+    if (value.length > 50) {
+      value = value.slice(0, 50).trim();
+      if (!value) continue;
+    }
+
+    const key = value.toLowerCase();
+    if (!seen.has(key)) {
+      seen.add(key);
+      cleaned.push(value);
+    }
+  }
+
+  return cleaned;
+}
+
+export function sanitizeProfileUpdate(
+  input: Record<string, unknown>
+): Record<string, unknown> {
+  const { dietary_restric, allergies, userId: _userId, ...rest } = input;
+  const output: Record<string, unknown> = { ...rest };
+
+  const normalizedDietary = normalizeDietaryRestrictions(dietary_restric);
+  if (normalizedDietary !== undefined) {
+    output.dietary_restric = normalizedDietary;
+  }
+
+  const sanitizedAllergies = sanitizeAllergies(allergies);
+  if (sanitizedAllergies !== undefined) {
+    output.allergies = sanitizedAllergies;
+  }
+
+  return output;
+}

--- a/backend/tests/profile.utils.test.ts
+++ b/backend/tests/profile.utils.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import {
+  normalizeDietaryRestrictions,
+  sanitizeAllergies,
+  sanitizeProfileUpdate,
+} from "../src/utils/profile.js";
+
+describe("profile utils", () => {
+  it("normalizes dietary options case-insensitively and de-dupes", () => {
+    const result = normalizeDietaryRestrictions([
+      "vegan",
+      "Vegan",
+      "Gluten-Free",
+      "gluten-free",
+    ]);
+
+    expect(result).toEqual(["Vegan", "Gluten-Free"]);
+  });
+
+  it("throws on invalid dietary options", () => {
+    expect(() =>
+      normalizeDietaryRestrictions(["Vegan", "Keto", "No-Meat"]),
+    ).toThrow(/Invalid dietary options/i);
+  });
+
+  it("sanitizes allergies and removes duplicates", () => {
+    const result = sanitizeAllergies([
+      "  peanuts ",
+      "Peanuts",
+      "shellfish<>",
+      "",
+      "egg\t",
+    ]);
+
+    expect(result).toEqual(["peanuts", "shellfish", "egg"]);
+  });
+
+  it("accepts comma-separated allergy strings", () => {
+    const result = sanitizeAllergies("nuts, soy ,  , eggs");
+    expect(result).toEqual(["nuts", "soy", "eggs"]);
+  });
+
+  it("sanitizes profile update payload and strips userId", () => {
+    const result = sanitizeProfileUpdate({
+      userId: "override",
+      dietary_restric: ["vegan"],
+      allergies: ["  nuts "],
+      bio: "Chef",
+    });
+
+    expect(result).toEqual({
+      dietary_restric: ["Vegan"],
+      allergies: ["nuts"],
+      bio: "Chef",
+    });
+  });
+});

--- a/e2e/profile-preferences.spec.ts
+++ b/e2e/profile-preferences.spec.ts
@@ -1,15 +1,14 @@
 import { test, expect } from "@playwright/test";
 
-test("user can log in, stay logged in, and log out", async ({ page }) => {
-  const email = `login+${Date.now()}@test.com`;
+test("user can edit dietary preferences and allergies and see them after reload", async ({ page }) => {
+  const email = `prefs+${Date.now()}@test.com`;
   const password = "Password1!";
 
-  // Create a non-customized user via BetterAuth API
   const registerRes = await page.request.post("http://localhost:4000/api/auth/sign-up/email", {
     data: {
       email,
       password,
-      name: "Login User",
+      name: "Preferences User",
     },
   });
   expect(registerRes.ok()).toBeTruthy();
@@ -24,7 +23,6 @@ test("user can log in, stay logged in, and log out", async ({ page }) => {
     content: `* { transition-duration: 0s !important; animation-duration: 0s !important; }`,
   });
 
-  // Wait explicitly for both email and password fields to guarantee they're rendered before interaction
   await page.waitForSelector('input[name="email"]', { timeout: 15000 });
   await page.waitForSelector('input[name="password"]', { timeout: 15000 });
 
@@ -56,28 +54,41 @@ test("user can log in, stay logged in, and log out", async ({ page }) => {
 
     const ageInput = page.getByLabel(/^Age/);
     await ageInput.fill("20");
-
     await page.getByRole("button", { name: "Complete Setup" }).click();
   }
 
-  // Verify user is in /dashboard
   await expect(page).toHaveURL(/\/dashboard/, { timeout: 30000 });
 
-  await expect(page.getByRole("button", { name: "Logout" })).toBeVisible();
+  await page.waitForURL(/\/dashboard/, { timeout: 30000 });
+  await page.locator(".header-account").click();
+  await page.locator(".user-card").waitFor({ state: "visible", timeout: 10000 });
+  await page.getByTitle("Options").click({ force: true });
+  await page.getByRole("button", { name: "Preferences" }).click();
+  await expect(page.getByText("Dietary Preferences")).toBeVisible();
 
-  // Navigate to home page
-  await page.goto("/");
-  await expect(page.getByRole("button", { name: "Logout" })).toBeVisible();
-  
-  await expect(page.getByRole("button", { name: "Logout" })).toBeVisible();
+  await page.getByRole("button", { name: "Vegan" }).click();
 
-  // Click logout button in navbar
-  await page.getByRole("button", { name: "Logout" }).click();
-  
-  // Should redirect to login or home
-  await page.waitForURL(/\/(login|)$/ , { timeout: 5000 });
+  const allergyInput = page.getByPlaceholder(/Search allergies/i);
+  await allergyInput.click();
+  await allergyInput.fill("pea");
+  await page.getByRole("button", { name: "Peanuts" }).click();
 
-  await page.goto("/dashboard");
-  await expect(page).toHaveURL(/\/login/, { timeout: 10000 });
-  await expect(page.getByRole("button", { name: "Log In" })).toBeVisible();
+  const save = page.getByRole("button", { name: "Save Changes" });
+  await expect(save).toBeVisible({ timeout: 5000 });
+  const waitSave = page.waitForResponse((res) =>
+    res.url().includes("/api/user/profile") && res.request().method() === "PUT"
+  );
+  await save.click();
+  await waitSave;
+
+  await page.waitForURL(/\/dashboard/, { timeout: 30000 });
+  await page.locator(".header-account").click();
+  await page.locator(".user-card").waitFor({ state: "visible", timeout: 10000 });
+  await page.getByTitle("Options").click({ force: true });
+  await page.getByRole("button", { name: "Preferences" }).click();
+
+  const veganButton = page.getByRole("button", { name: "Vegan" });
+  await expect(veganButton).toHaveClass(/bg-accent/);
+
+  await expect(page.getByText("Peanuts")).toBeVisible();
 });

--- a/e2e/registration.spec.ts
+++ b/e2e/registration.spec.ts
@@ -21,19 +21,23 @@ test("user can register and reaches preferences flow", async ({ page }) => {
     page.getByRole("heading", { name: "Customize Your Culinary Experience" })
   ).toBeVisible({ timeout: 20000 });
 
-  const firstCuisine = page.locator('text="Favorite Cuisines"').locator('..').locator('.cursor-pointer').first();
+  const firstCuisine = page
+    .locator('text="Favorite Cuisines"')
+    .locator("..")
+    .locator(".cursor-pointer")
+    .first();
   await firstCuisine.click();
 
-  const allergiesInput = page.getByPlaceholder(/Search allergies/i);
-  await allergiesInput.click();
-  await page.keyboard.press("Enter");
+  await page.getByRole("button", { name: "Next: Personal Details" }).click();
 
   await expect(
     page.getByRole("heading", { name: "Tell Us About Yourself" })
   ).toBeVisible({ timeout: 10000 });
 
-  await page.getByLabel(/^Age/).fill("22");
-  await page.keyboard.press("Enter");
+  const ageInput = page.getByLabel(/^Age/);
+  await ageInput.fill("20");
 
-  await expect(page).toHaveURL(/\/dashboard/, { timeout: 10000 });
+  await page.getByRole("button", { name: "Complete Setup" }).click();
+
+  await expect(page).toHaveURL(/\/dashboard/, { timeout: 20000 });
 });

--- a/frontend/tests/AccountPreferences.test.tsx
+++ b/frontend/tests/AccountPreferences.test.tsx
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+const { mockSetUser, mockAxiosPut, mockUseUser } = vi.hoisted(() => ({
+  mockSetUser: vi.fn(),
+  mockAxiosPut: vi.fn(),
+  mockUseUser: vi.fn(),
+}));
+
+vi.mock("@context/UserContext", () => ({
+  useUser: mockUseUser,
+}));
+
+vi.mock("axios", () => ({
+  default: {
+    put: mockAxiosPut,
+  },
+}));
+
+vi.mock("react-hot-toast", () => ({
+  default: {
+    loading: vi.fn(() => "toast-id"),
+    dismiss: vi.fn(),
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import axios from "axios";
+import AccountPreferences from "@/components/ui/Dashboard/contents/settings/AccountPreferences";
+
+describe("AccountPreferences", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseUser.mockReturnValue({
+      user: {
+        id: "u1",
+        name: "Alice",
+        email: "a@b.com",
+        dietary_restric: [],
+        allergies: [],
+        skill_level: "beginner",
+        cuisines_pref: [],
+      },
+      setUser: mockSetUser,
+      loading: false,
+    });
+  });
+
+  it("shows existing profile dietary preferences and allergies", () => {
+    mockUseUser.mockReturnValueOnce({
+      user: {
+        id: "u1",
+        name: "Alice",
+        email: "a@b.com",
+        dietary_restric: ["Vegan"],
+        allergies: ["Peanuts"],
+        skill_level: "beginner",
+        cuisines_pref: [],
+      },
+      setUser: mockSetUser,
+      loading: false,
+    });
+
+    render(<AccountPreferences />);
+
+    const veganButton = screen.getByRole("button", { name: "Vegan" });
+    expect(veganButton.className).toMatch(/ring-3/);
+
+    expect(screen.getByText("Peanuts")).toBeInTheDocument();
+  });
+
+  it("saves updated dietary restrictions and allergies", async () => {
+    mockAxiosPut.mockResolvedValue({
+      data: { user: { id: "u1", dietary_restric: ["Vegan"], allergies: ["Peanuts"] } },
+    });
+
+    render(<AccountPreferences />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Vegan" }));
+
+    const allergyInput = screen.getByPlaceholderText(/Search allergies/i);
+    fireEvent.click(allergyInput);
+    fireEvent.change(allergyInput, { target: { value: "Pea" } });
+
+    fireEvent.click(screen.getByRole("button", { name: "Peanuts" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Save Changes" })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    await waitFor(() => {
+      expect(axios.put).toHaveBeenCalledWith(
+        expect.stringContaining("/user/profile"),
+        expect.objectContaining({
+          userId: "u1",
+          dietary_restric: ["Vegan"],
+          allergies: ["Peanuts"],
+        }),
+        { withCredentials: true },
+      );
+    });
+
+    expect(mockSetUser).toHaveBeenCalled();
+  });
+});

--- a/frontend/tests/AccountSettings.test.tsx
+++ b/frontend/tests/AccountSettings.test.tsx
@@ -61,7 +61,8 @@ describe("AccountSettings password flows", () => {
       expect(mockListAccounts).toHaveBeenCalled();
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "Set up" }));
+    const setupButton = await screen.findByRole("button", { name: "Set up" });
+    fireEvent.click(setupButton);
 
     fireEvent.change(screen.getByPlaceholderText("At least 8 characters"), {
       target: { value: "Password1!" },
@@ -90,7 +91,8 @@ describe("AccountSettings password flows", () => {
       expect(mockListAccounts).toHaveBeenCalled();
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "Update" }));
+    const updateButton = await screen.findByRole("button", { name: "Update" });
+    fireEvent.click(updateButton);
 
     fireEvent.change(screen.getByPlaceholderText("Current password"), {
       target: { value: "OldPass1!" },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "@playwright/test";
 
 export default defineConfig({
   testDir: "./e2e",
+  workers: 1,
   timeout: 60_000,
   expect: {
     timeout: 10_000,


### PR DESCRIPTION
Summary:
- add profile update sanitization/validation utilities for dietary options and allergies
- add backend unit tests for profile normalization and sanitization
- add frontend unit tests for preferences save flow
- add Playwright e2e coverage for profile preferences edit/save/reload
- stabilize e2e flows for customization and set Playwright workers to 1
-Updated contribution log sprint 2

closes #45, closes #46