### PR TITLE
feat(meal-plans): GET /api/meal-plans/:id — Story 8     

### DIFF
--- a/Sprints/ContributionLog/contribution-log-paulina.md
+++ b/Sprints/ContributionLog/contribution-log-paulina.md
@@ -30,5 +30,6 @@
 | ---------- | -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
 | 2026-03-11 | Meal Plan Schema (Story 7) | Designed and implemented MealPlan and MealPlanEntry Mongoose models with unique indexes for duplicate prevention (one plan per user per week, one recipe per day/meal slot). Added dayOfWeek and mealType enums to shared/constants following the existing skill-levels pattern. | 1.5h       |
 | 2026-03-11 | Sprint 3 Meeting Minutes   | Wrote meeting minutes for the March 6 Sprint 3 planning session.                                                                                                                                                                                                                 | 0.25h      |
+| 2026-03-15 | Meal Plan Read API (Story 8) | Implemented GET /api/meal-plans/:id endpoint. Created service, controller, and route module. Service validates ObjectId, fetches the meal plan, populates entries with recipe title via Mongoose populate, and builds a deterministic 7-day × 4-meal-type nested response (null for empty slots). Added MealSlot and MealPlanResponse types. Registered route in the main router. | 1h         |
 
-**Total Time:** 1.75h
+**Total Time:** 3h

--- a/backend/src/controllers/meal-plan.controller.ts
+++ b/backend/src/controllers/meal-plan.controller.ts
@@ -1,0 +1,16 @@
+import { Request, Response, NextFunction } from "express";
+import { getMealPlanById as getMealPlanByIdService } from "../services/meal-plan.service.js";
+
+export async function getMealPlanById(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
+  try {
+    const id = req.params.id as string;
+    const result = await getMealPlanByIdService(id);
+    res.status(200).json({ success: true, data: result });
+  } catch (error) {
+    next(error);
+  }
+}

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -2,6 +2,7 @@ import { Router } from "express";
 import authRoutes from "./auth.js";
 import userRoutes from "./user.js";
 import recipeRoutes from "./recipes.js";
+import mealPlanRoutes from "./meal-plans.js";
 
 const router = Router();
 
@@ -14,5 +15,6 @@ router.get("/health", (_req, res) => {
 router.use("/api/auth", authRoutes);
 router.use("/api/user", userRoutes);   // profile update lives here, outside /api/auth/*
 router.use("/api/recipes", recipeRoutes);
+router.use("/api/meal-plans", mealPlanRoutes);
 
 export default router;

--- a/backend/src/routes/meal-plans.ts
+++ b/backend/src/routes/meal-plans.ts
@@ -1,0 +1,9 @@
+import { Router } from "express";
+import { requireSession } from "../middleware/auth.middleware.js";
+import { getMealPlanById } from "../controllers/meal-plan.controller.js";
+
+const router = Router();
+
+router.get("/:id", requireSession, getMealPlanById);
+
+export default router;

--- a/backend/src/services/meal-plan.service.ts
+++ b/backend/src/services/meal-plan.service.ts
@@ -1,0 +1,51 @@
+import mongoose from "mongoose";
+import { MealPlan } from "../models/meal-plan.model.js";
+import { MealPlanEntry } from "../models/meal-plan-entry.model.js";
+import { dayOfWeekValues, mealTypeValues } from "@masterchef/shared/constants";
+import type { DayOfWeek, MealType } from "@masterchef/shared/constants";
+import type { ApiError, MealPlanResponse } from "../types/index.js";
+
+export async function getMealPlanById(id: string): Promise<MealPlanResponse> {
+  if (!mongoose.Types.ObjectId.isValid(id)) {
+    const error: ApiError = new Error("Invalid meal plan ID");
+    error.statusCode = 400;
+    throw error;
+  }
+
+  const mealPlan = await MealPlan.findById(id);
+  if (!mealPlan) {
+    const error: ApiError = new Error("Meal plan not found");
+    error.statusCode = 404;
+    throw error;
+  }
+
+  const entries = await MealPlanEntry.find({ mealPlanId: id }).populate<{
+    recipeId: { _id: mongoose.Types.ObjectId; title: string };
+  }>("recipeId", "title");
+
+  const days = {} as MealPlanResponse["days"];
+
+  for (const day of dayOfWeekValues) {
+    days[day] = {} as Record<MealType, MealPlanResponse["days"][DayOfWeek][MealType]>;
+    for (const meal of mealTypeValues) {
+      const entry = entries.find(
+        (e) => e.dayOfWeek === day && e.mealType === meal
+      );
+      if (entry && entry.recipeId) {
+        days[day][meal] = {
+          recipeId: entry.recipeId._id.toString(),
+          title: entry.recipeId.title,
+          notes: entry.notes ?? "",
+        };
+      } else {
+        days[day][meal] = null;
+      }
+    }
+  }
+
+  return {
+    id: mealPlan._id.toString(),
+    weekStartDate: mealPlan.weekStartDate,
+    days,
+  };
+}

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -140,3 +140,19 @@ export interface RecommendationResult {
   totalIngredients: number;
   missingIngredients: string[];
 }
+
+// ── Meal Plan types ────────────────────────────────────────────
+
+import type { DayOfWeek, MealType } from "@masterchef/shared/constants";
+
+export interface MealSlot {
+  recipeId: string;
+  title: string;
+  notes: string;
+}
+
+export interface MealPlanResponse {
+  id: string;
+  weekStartDate: Date;
+  days: Record<DayOfWeek, Record<MealType, MealSlot | null>>;
+}


### PR DESCRIPTION
Summary                                                                                        
                                                                                                 
  - Adds GET /api/meal-plans/:id endpoint (session-protected) that returns a meal plan as a      
  nested object keyed by day and meal type                                                     
  - All 7 days and all 4 meal types are always present in the response, empty slots are null,
  never omitted
  - Populated slots include recipeId, title (from recipe), and notes
  - Handles 400 for invalid ObjectId, 404 for missing plan, 401 for no session

  Files Changed

  - backend/src/services/meal-plan.service.ts (new), core logic: ObjectId validation, DB fetch,
  populate, grid builder
  - backend/src/controllers/meal-plan.controller.ts (new) — thin controller delegating to service
  - backend/src/routes/meal-plans.ts (new) — router with requireSession guard
  - backend/src/types/index.ts — added MealSlot and MealPlanResponse interfaces
  - backend/src/routes/index.ts — registered /api/meal-plans router

  Test Plan

  - GET /api/meal-plans/<valid-id> with session → 200, all 7 days and 4 meal types present
  - Populated slots have recipeId, title, notes — empty slots are null
  - GET /api/meal-plans/<nonexistent-id> → 404
  - GET /api/meal-plans/<bad-id> → 400
  - GET /api/meal-plans/<valid-id> without session → 401