### PR TITLE
Implement Create Meal Plan API

### DIFF
--- a/backend/src/controllers/meal-plan.controller.ts
+++ b/backend/src/controllers/meal-plan.controller.ts
@@ -1,7 +1,28 @@
 import { Request, Response, NextFunction } from "express";
-import { getMealPlanById as getMealPlanByIdService, createMealPlanEntry as createMealPlanEntryService } from "../services/meal-plan.service.js";
+import { createMealPlan as createMealPlanService, getMealPlanById as getMealPlanByIdService, createMealPlanEntry as createMealPlanEntryService } from "../services/meal-plan.service.js";
 import type { AuthenticatedRequest } from "../middleware/auth.middleware.js";
 import type { DayOfWeek, MealType } from "@masterchef/shared/constants";
+
+export async function createMealPlan(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
+  try {
+    const { week_start_date } = req.body as { week_start_date: string };
+    const userId = (req as AuthenticatedRequest).session.user.id;
+
+    if (!week_start_date) {
+      res.status(400).json({ success: false, error: "week_start_date is required" });
+      return;
+    }
+
+    const result = await createMealPlanService({ userId, weekStartDate: week_start_date });
+    res.status(201).json({ success: true, data: result });
+  } catch (error) {
+    next(error);
+  }
+}
 
 export async function getMealPlanById(
   req: Request,

--- a/backend/src/routes/meal-plans.ts
+++ b/backend/src/routes/meal-plans.ts
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import { requireSession } from "../middleware/auth.middleware.js";
-import { getMealPlanById, createMealPlanEntry } from "../controllers/meal-plan.controller.js";
+import { createMealPlan, getMealPlanById, createMealPlanEntry } from "../controllers/meal-plan.controller.js";
 
 const router = Router();
 
+router.post("/", requireSession, createMealPlan);
 router.get("/:id", requireSession, getMealPlanById);
 router.post("/:id/entries", requireSession, createMealPlanEntry);
 

--- a/backend/src/services/meal-plan.service.ts
+++ b/backend/src/services/meal-plan.service.ts
@@ -4,7 +4,44 @@ import { MealPlanEntry } from "../models/meal-plan-entry.model.js";
 import { Recipe } from "../models/recipe.model.js";
 import { dayOfWeekValues, mealTypeValues } from "@masterchef/shared/constants";
 import type { DayOfWeek, MealType } from "@masterchef/shared/constants";
-import type { ApiError, MealPlanResponse, CreateMealPlanEntryInput, MealPlanEntryResponse } from "../types/index.js";
+import type { ApiError, CreateMealPlanInput, MealPlanResponse, CreateMealPlanEntryInput, MealPlanEntryResponse } from "../types/index.js";
+
+export async function createMealPlan(input: CreateMealPlanInput): Promise<MealPlanResponse> {
+  const { userId, weekStartDate: weekStartDateStr } = input;
+
+  const weekStartDate = new Date(weekStartDateStr);
+  if (isNaN(weekStartDate.getTime())) {
+    const error: ApiError = new Error("Invalid week_start_date");
+    error.statusCode = 400;
+    throw error;
+  }
+
+  if (weekStartDate.getUTCDay() !== 1) {
+    const error: ApiError = new Error("week_start_date must be a Monday");
+    error.statusCode = 400;
+    throw error;
+  }
+
+  // Normalize to midnight UTC
+  weekStartDate.setUTCHours(0, 0, 0, 0);
+
+  const existing = await MealPlan.findOne({
+    userId: new mongoose.Types.ObjectId(userId),
+    weekStartDate,
+  });
+  if (existing) {
+    const error: ApiError = new Error("A meal plan for this week already exists");
+    error.statusCode = 409;
+    throw error;
+  }
+
+  const mealPlan = await MealPlan.create({
+    userId: new mongoose.Types.ObjectId(userId),
+    weekStartDate,
+  });
+
+  return getMealPlanById(mealPlan._id.toString());
+}
 
 export async function getMealPlanById(id: string): Promise<MealPlanResponse> {
   if (!mongoose.Types.ObjectId.isValid(id)) {

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -151,6 +151,11 @@ export interface MealSlot {
   notes: string;
 }
 
+export interface CreateMealPlanInput {
+  userId: string;
+  weekStartDate: string;
+}
+
 export interface MealPlanResponse {
   id: string;
   weekStartDate: Date;


### PR DESCRIPTION
## Implement Create Meal Plan API

### Summary
- Added `POST /api/meal-plans` endpoint that creates a new meal plan for the authenticated user
- Accepts `week_start_date` in the request body (must be a Monday)
- Returns the created meal plan with HTTP 201, including a fully structured day/meal slot layout
- Validates that the user doesn't already have a plan for the given week — returns 409 if a duplicate is found
- Protected by `requireSession` middleware; the user ID is derived from the session (not the request body)

### Changes
- **`types/index.ts`** — added `CreateMealPlanInput` interface
- **`services/meal-plan.service.ts`** — added `createMealPlan()` with date validation (must be a Monday), duplicate check, and plan creation
- **`controllers/meal-plan.controller.ts`** — added `createMealPlan` handler extracting `week_start_date` from body and `userId` from session
- **`routes/meal-plans.ts`** — registered `POST /` route with `requireSession`

closes #126 
Closes #122
