### PR TITLE
feat(meal-plans): add POST /api/meal-plans/:id/entries endpoint

### DIFF
--- a/Sprints/ContributionLog/contribution-log-paulina.md
+++ b/Sprints/ContributionLog/contribution-log-paulina.md
@@ -31,5 +31,6 @@
 | 2026-03-11 | Meal Plan Schema (Story 7) | Designed and implemented MealPlan and MealPlanEntry Mongoose models with unique indexes for duplicate prevention (one plan per user per week, one recipe per day/meal slot). Added dayOfWeek and mealType enums to shared/constants following the existing skill-levels pattern. | 1.5h       |
 | 2026-03-11 | Sprint 3 Meeting Minutes   | Wrote meeting minutes for the March 6 Sprint 3 planning session.                                                                                                                                                                                                                 | 0.25h      |
 | 2026-03-15 | Meal Plan Read API (Story 8) | Implemented GET /api/meal-plans/:id endpoint. Created service, controller, and route module. Service validates ObjectId, fetches the meal plan, populates entries with recipe title via Mongoose populate, and builds a deterministic 7-day × 4-meal-type nested response (null for empty slots). Added MealSlot and MealPlanResponse types. Registered route in the main router. | 1h         |
+| 2026-03-20 | Assign Recipe API (Story 9) | Implemented POST /api/meal-plans/:id/entries endpoint. Added isPublic field to Recipe model. Service verifies meal plan ownership (403), validates recipe access (own or public, 403), creates MealPlanEntry, and handles duplicate slot conflict (409). Added CreateMealPlanEntryInput and MealPlanEntryResponse types. | 1h         |
 
-**Total Time:** 3h
+**Total Time:** 4h

--- a/backend/src/controllers/meal-plan.controller.ts
+++ b/backend/src/controllers/meal-plan.controller.ts
@@ -1,5 +1,7 @@
 import { Request, Response, NextFunction } from "express";
-import { getMealPlanById as getMealPlanByIdService } from "../services/meal-plan.service.js";
+import { getMealPlanById as getMealPlanByIdService, createMealPlanEntry as createMealPlanEntryService } from "../services/meal-plan.service.js";
+import type { AuthenticatedRequest } from "../middleware/auth.middleware.js";
+import type { DayOfWeek, MealType } from "@masterchef/shared/constants";
 
 export async function getMealPlanById(
   req: Request,
@@ -10,6 +12,36 @@ export async function getMealPlanById(
     const id = req.params.id as string;
     const result = await getMealPlanByIdService(id);
     res.status(200).json({ success: true, data: result });
+  } catch (error) {
+    next(error);
+  }
+}
+
+export async function createMealPlanEntry(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
+  try {
+    const mealPlanId = req.params.id as string;
+    const userId = (req as AuthenticatedRequest).session.user.id;
+    const { day_of_week, meal_type, recipe_id, notes } = req.body as {
+      day_of_week: DayOfWeek;
+      meal_type: MealType;
+      recipe_id: string;
+      notes?: string;
+    };
+
+    const result = await createMealPlanEntryService({
+      mealPlanId,
+      userId,
+      dayOfWeek: day_of_week,
+      mealType: meal_type,
+      recipeId: recipe_id,
+      notes,
+    });
+
+    res.status(201).json({ success: true, data: result });
   } catch (error) {
     next(error);
   }

--- a/backend/src/models/recipe.model.ts
+++ b/backend/src/models/recipe.model.ts
@@ -21,6 +21,7 @@ export interface IRecipe extends Document {
   dietaryTags: string[];
   containsAllergens: string[];
   createdBy: mongoose.Types.ObjectId;
+  isPublic: boolean;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -109,6 +110,7 @@ const recipeSchema = new Schema<IRecipe>(
       required: [true, "Creator user ID is required"],
       index: true,
     },
+    isPublic: { type: Boolean, default: false },
   },
   {
     timestamps: true,

--- a/backend/src/routes/meal-plans.ts
+++ b/backend/src/routes/meal-plans.ts
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import { requireSession } from "../middleware/auth.middleware.js";
-import { getMealPlanById } from "../controllers/meal-plan.controller.js";
+import { getMealPlanById, createMealPlanEntry } from "../controllers/meal-plan.controller.js";
 
 const router = Router();
 
 router.get("/:id", requireSession, getMealPlanById);
+router.post("/:id/entries", requireSession, createMealPlanEntry);
 
 export default router;

--- a/backend/src/services/meal-plan.service.ts
+++ b/backend/src/services/meal-plan.service.ts
@@ -1,9 +1,10 @@
 import mongoose from "mongoose";
 import { MealPlan } from "../models/meal-plan.model.js";
 import { MealPlanEntry } from "../models/meal-plan-entry.model.js";
+import { Recipe } from "../models/recipe.model.js";
 import { dayOfWeekValues, mealTypeValues } from "@masterchef/shared/constants";
 import type { DayOfWeek, MealType } from "@masterchef/shared/constants";
-import type { ApiError, MealPlanResponse } from "../types/index.js";
+import type { ApiError, MealPlanResponse, CreateMealPlanEntryInput, MealPlanEntryResponse } from "../types/index.js";
 
 export async function getMealPlanById(id: string): Promise<MealPlanResponse> {
   if (!mongoose.Types.ObjectId.isValid(id)) {
@@ -48,4 +49,82 @@ export async function getMealPlanById(id: string): Promise<MealPlanResponse> {
     weekStartDate: mealPlan.weekStartDate,
     days,
   };
+}
+
+export async function createMealPlanEntry(
+  input: CreateMealPlanEntryInput
+): Promise<MealPlanEntryResponse> {
+  const { mealPlanId, userId, dayOfWeek, mealType, recipeId, notes } = input;
+
+  if (!mongoose.Types.ObjectId.isValid(mealPlanId)) {
+    const error: ApiError = new Error("Invalid meal plan ID");
+    error.statusCode = 400;
+    throw error;
+  }
+
+  if (!mongoose.Types.ObjectId.isValid(recipeId)) {
+    const error: ApiError = new Error("Invalid recipe ID");
+    error.statusCode = 400;
+    throw error;
+  }
+
+  const mealPlan = await MealPlan.findById(mealPlanId);
+  if (!mealPlan) {
+    const error: ApiError = new Error("Meal plan not found");
+    error.statusCode = 404;
+    throw error;
+  }
+
+  if (mealPlan.userId.toString() !== userId) {
+    const error: ApiError = new Error("You do not own this meal plan");
+    error.statusCode = 403;
+    throw error;
+  }
+
+  const recipe = await Recipe.findById(recipeId);
+  if (!recipe) {
+    const error: ApiError = new Error("Recipe not found");
+    error.statusCode = 404;
+    throw error;
+  }
+
+  if (recipe.createdBy.toString() !== userId && !recipe.isPublic) {
+    const error: ApiError = new Error("You do not have access to this recipe");
+    error.statusCode = 403;
+    throw error;
+  }
+
+  try {
+    const entry = await MealPlanEntry.create({
+      mealPlanId,
+      dayOfWeek,
+      mealType,
+      recipeId,
+      notes,
+    });
+
+    return {
+      id: entry._id.toString(),
+      mealPlanId: entry.mealPlanId.toString(),
+      dayOfWeek: entry.dayOfWeek,
+      mealType: entry.mealType,
+      recipeId: entry.recipeId.toString(),
+      notes: entry.notes,
+      createdAt: entry.createdAt.toISOString(),
+    };
+  } catch (err: unknown) {
+    if (
+      typeof err === "object" &&
+      err !== null &&
+      "code" in err &&
+      (err as { code: number }).code === 11000
+    ) {
+      const error: ApiError = new Error(
+        "A recipe is already assigned to this slot"
+      );
+      error.statusCode = 409;
+      throw error;
+    }
+    throw err;
+  }
 }

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -156,3 +156,22 @@ export interface MealPlanResponse {
   weekStartDate: Date;
   days: Record<DayOfWeek, Record<MealType, MealSlot | null>>;
 }
+
+export interface CreateMealPlanEntryInput {
+  mealPlanId: string;
+  userId: string;
+  dayOfWeek: DayOfWeek;
+  mealType: MealType;
+  recipeId: string;
+  notes?: string;
+}
+
+export interface MealPlanEntryResponse {
+  id: string;
+  mealPlanId: string;
+  dayOfWeek: string;
+  mealType: string;
+  recipeId: string;
+  notes?: string;
+  createdAt: string;
+}


### PR DESCRIPTION
## Story 9: Assign Recipes to Meal Plan

### What changed
- Added `POST /api/meal-plans/:id/entries` endpoint to assign a recipe to a specific day and meal type slot in a meal plan
- Added `isPublic` field to the Recipe model — entries accept recipes owned by the user or marked as public
- Added `CreateMealPlanEntryInput` and `MealPlanEntryResponse` types

### How it works
1. Verifies the authenticated user owns the meal plan (403 if not)
2. Validates the recipe exists and is accessible — owned by the user or `isPublic: true` (403 if neither)
3. Creates a `MealPlanEntry` document for the given `day_of_week` + `meal_type` slot
4. Returns the created entry with HTTP 201
5. Returns 409 if a recipe is already assigned to that slot

### Request body
```json
{
  "day_of_week": "Monday",
  "meal_type": "lunch",
  "recipe_id": "<objectId>",
  "notes": "optional"
}
