### PR TITLE
Story 11: Prevent Duplicates in Same Week - Add duplicate recipe validation to Assign API

### DIFF
--- a/backend/src/services/meal-plan.service.ts
+++ b/backend/src/services/meal-plan.service.ts
@@ -131,6 +131,22 @@ export async function createMealPlanEntry(
     throw error;
   }
 
+  const duplicateRecipe = await MealPlanEntry.findOne({
+    mealPlanId,
+    recipeId,
+    mealType: { $ne: mealType },
+  });
+  if (duplicateRecipe) {
+    const error: ApiError = new Error(
+      `This recipe is already assigned to ${duplicateRecipe.dayOfWeek}, ${duplicateRecipe.mealType} this week.`
+    );
+    error.statusCode = 409;
+    (error as ApiError & { details?: { existingMealType?: string } }).details = {
+      existingMealType: duplicateRecipe.mealType,
+    };
+    throw error;
+  }
+
   try {
     const entry = await MealPlanEntry.create({
       mealPlanId,


### PR DESCRIPTION
 Added recipeId duplicate prevention within the same mealplan 
Added the 409 error message  'This recipe is already assigned to [Day, Meal Type] this week.' if a duplicate is detected.

Changes
backend/src/services/meal-plan.service.ts 