### PR TITLE
Add Unit Tests for Recipe CRUD, Search, and Filter Acceptance Criteria

### DIFF
--- a/backend/tests/recipe-search-filter.service.test.ts
+++ b/backend/tests/recipe-search-filter.service.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import mongoose from "mongoose";
+import { MongoMemoryServer } from "mongodb-memory-server";
+
+import { User } from "../src/models/user.model.js";
+import { Recipe } from "../src/models/recipe.model.js";
+import { getRecipes, searchRecipes } from "../src/services/recipe.service.js";
+
+describe("Recipe search and filters (US.05 / US.06)", () => {
+  let mongoServer: MongoMemoryServer;
+  let ownerId: string;
+
+  beforeAll(async () => {
+    mongoServer = await MongoMemoryServer.create();
+    await mongoose.connect(mongoServer.getUri());
+    await User.init();
+    await Recipe.init();
+  });
+
+  beforeEach(async () => {
+    await Recipe.deleteMany({});
+    await User.deleteMany({});
+
+    const owner = await User.create({
+      email: "seed-owner@test.com",
+      name: "Seed Owner",
+      passwordHash: "hash",
+    });
+    ownerId = owner._id.toString();
+
+    const seeds = [
+      {
+        title: "Creamy Pasta Alfredo",
+        description: "Rich pasta with cream sauce",
+        ingredients: [{ foodItem: "Pasta", amount: 200, unit: "g" }],
+        cookingTime: 20,
+        skillLevel: "beginner",
+        dietaryTags: ["vegetarian"],
+      },
+      {
+        title: "Chicken Pasta Primavera",
+        description: "Chicken and pasta in one pan",
+        ingredients: [{ foodItem: "Chicken Breast", amount: 250, unit: "g" }],
+        cookingTime: 35,
+        skillLevel: "intermediate",
+        dietaryTags: [],
+      },
+      {
+        title: "Vegan Chickpea Bowl",
+        description: "Protein-rich vegan bowl",
+        ingredients: [{ foodItem: "Chickpeas", amount: 200, unit: "g" }],
+        cookingTime: 25,
+        skillLevel: "beginner",
+        dietaryTags: ["vegan"],
+      },
+      {
+        title: "Quick Tomato Soup",
+        description: "Simple 15-minute soup",
+        ingredients: [{ foodItem: "Tomato", amount: 4, unit: "unit" }],
+        cookingTime: 15,
+        skillLevel: "beginner",
+        dietaryTags: ["vegetarian", "gluten-free"],
+      },
+      {
+        title: "Beef Stew",
+        description: "Slow-cooked comfort meal",
+        ingredients: [{ foodItem: "Beef", amount: 400, unit: "g" }],
+        cookingTime: 90,
+        skillLevel: "advanced",
+        dietaryTags: [],
+      },
+      {
+        title: "Mushroom Risotto",
+        description: "Creamy rice dish",
+        ingredients: [{ foodItem: "Mushroom", amount: 200, unit: "g" }],
+        cookingTime: 40,
+        skillLevel: "intermediate",
+        dietaryTags: ["vegetarian"],
+      },
+      {
+        title: "Chicken Stir Fry",
+        description: "Chicken with vegetables",
+        ingredients: [{ foodItem: "Chicken", amount: 300, unit: "g" }],
+        cookingTime: 30,
+        skillLevel: "intermediate",
+        dietaryTags: [],
+      },
+      {
+        title: "Gluten-Free Pancakes",
+        description: "Breakfast favorite",
+        ingredients: [{ foodItem: "Gluten-Free Flour", amount: 150, unit: "g" }],
+        cookingTime: 18,
+        skillLevel: "beginner",
+        dietaryTags: ["gluten-free", "vegetarian"],
+      },
+      {
+        title: "Tofu Curry",
+        description: "Spiced tofu curry",
+        ingredients: [{ foodItem: "Tofu", amount: 250, unit: "g" }],
+        cookingTime: 45,
+        skillLevel: "intermediate",
+        dietaryTags: ["vegan", "vegetarian"],
+      },
+      {
+        title: "Pasta Salad",
+        description: "Cold pasta for lunch",
+        ingredients: [{ foodItem: "Pasta", amount: 200, unit: "g" }],
+        cookingTime: 12,
+        skillLevel: "beginner",
+        dietaryTags: ["vegetarian"],
+      },
+    ];
+
+    await Recipe.insertMany(
+      seeds.map((seed) => ({
+        title: seed.title,
+        description: seed.description,
+        ingredients: seed.ingredients,
+        steps: ["Step 1", "Step 2"],
+        cookingTime: seed.cookingTime,
+        servings: 2,
+        skillLevel: seed.skillLevel,
+        dietaryTags: seed.dietaryTags,
+        containsAllergens: [],
+        isPublic: true,
+        createdBy: ownerId,
+      })),
+    );
+  });
+
+  afterAll(async () => {
+    await mongoose.disconnect();
+    await mongoServer.stop();
+  });
+
+  it("searches by keyword across title, description, and ingredients (case-insensitive)", async () => {
+    const pasta = await searchRecipes({ q: "PaStA" });
+    expect(pasta.recipes.length).toBeGreaterThanOrEqual(3);
+    expect(pasta.recipes.some((r) => r.title.includes("Pasta"))).toBe(true);
+    expect(pasta.recipes.some((r) => r.title === "Beef Stew")).toBe(false);
+  });
+
+  it("applies filters individually (time, difficulty alias, dietary tags)", async () => {
+    const max30 = await getRecipes({ max_time: 30 });
+    expect(max30.recipes.length).toBeGreaterThan(0);
+    expect(max30.recipes.every((r) => r.cookingTime <= 30)).toBe(true);
+
+    const mediumAlias = await getRecipes({ difficulty: "intermediate" });
+    expect(mediumAlias.recipes.length).toBeGreaterThan(0);
+    expect(mediumAlias.recipes.every((r) => r.skillLevel === "intermediate")).toBe(
+      true,
+    );
+
+    const vegetarian = await getRecipes({ dietary_tags: ["vegetarian"] });
+    expect(vegetarian.recipes.length).toBeGreaterThan(0);
+    expect(
+      vegetarian.recipes.every((r) => r.dietaryTags.includes("vegetarian")),
+    ).toBe(true);
+  });
+
+  it("applies combined search + filters with AND logic and supports clear/no-results behavior", async () => {
+    const combined = await getRecipes({
+      search: "chicken",
+      max_time: 45,
+      difficulty: "intermediate",
+    });
+
+    expect(combined.recipes.length).toBeGreaterThanOrEqual(1);
+    expect(
+      combined.recipes.every(
+        (r) =>
+          r.cookingTime <= 45 &&
+          r.skillLevel === "intermediate" &&
+          `${r.title} ${r.description}`.toLowerCase().includes("chicken"),
+      ),
+    ).toBe(true);
+
+    const noResults = await getRecipes({
+      search: "chicken",
+      max_time: 10,
+      difficulty: "expert",
+    });
+    expect(noResults.recipes.length).toBe(0);
+
+    const all = await getRecipes({});
+    expect(all.total).toBe(10);
+
+    const ownerAll = await getRecipes({ createdBy: ownerId });
+    expect(ownerAll.total).toBe(10);
+  });
+});
+

--- a/backend/tests/recipe.service.test.ts
+++ b/backend/tests/recipe.service.test.ts
@@ -1,0 +1,164 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+  beforeEach,
+} from "vitest";
+import mongoose from "mongoose";
+import { MongoMemoryServer } from "mongodb-memory-server";
+
+import { User } from "../src/models/user.model.js";
+import { Recipe } from "../src/models/recipe.model.js";
+import {
+  createRecipe,
+  updateRecipe,
+  deleteRecipe,
+  getRecipeById,
+  getRecipes,
+  searchRecipes,
+} from "../src/services/recipe.service.js";
+
+describe("Recipe service (US.04)", () => {
+  let mongoServer: MongoMemoryServer;
+
+  beforeAll(async () => {
+    mongoServer = await MongoMemoryServer.create();
+    await mongoose.connect(mongoServer.getUri());
+    await User.init();
+    await Recipe.init();
+  });
+
+  beforeEach(async () => {
+    await Recipe.deleteMany({});
+    await User.deleteMany({});
+  });
+
+  afterAll(async () => {
+    await mongoose.disconnect();
+    await mongoServer.stop();
+  });
+
+  async function createUser(email: string, name = "Test User") {
+    return User.create({
+      email,
+      name,
+      passwordHash: "hash",
+    });
+  }
+
+  function carbonaraInput(userId: string) {
+    return {
+      userId,
+      title: "Spaghetti Carbonara",
+      description: "Classic Italian pasta dish",
+      ingredients: [
+        { foodItem: "Spaghetti", amount: 200, unit: "g" },
+        { foodItem: "Pancetta", amount: 100, unit: "g" },
+        { foodItem: "Eggs", amount: 2, unit: "unit" },
+        { foodItem: "Parmesan", amount: 50, unit: "g" },
+      ],
+      steps: [
+        "Boil pasta",
+        "Cook pancetta",
+        "Mix eggs and cheese",
+        "Combine all",
+      ],
+      cookingTime: 15,
+      servings: 2,
+      skillLevel: "intermediate",
+      isShared: true,
+    } as const;
+  }
+
+  it("creates, updates, and deletes a recipe for its owner", async () => {
+    const owner = await createUser("owner-us04@test.com", "Owner");
+
+    const created = await createRecipe(carbonaraInput(owner._id.toString()));
+    expect(created.title).toBe("Spaghetti Carbonara");
+    expect(created.createdBy).toBe(owner._id.toString());
+    expect(created.createdByName).toBe("Owner");
+
+    const ownerList = await getRecipes({ createdBy: owner._id.toString() });
+    expect(ownerList.recipes.some((r) => r.id === created.id)).toBe(true);
+
+    const updated = await updateRecipe({
+      recipeId: created.id,
+      userId: owner._id.toString(),
+      title: "Authentic Spaghetti Carbonara",
+      servings: 3,
+    });
+
+    expect(updated.title).toBe("Authentic Spaghetti Carbonara");
+    expect(updated.servings).toBe(3);
+
+    const fromDb = await getRecipeById(created.id);
+    expect(fromDb.title).toBe("Authentic Spaghetti Carbonara");
+    expect(fromDb.servings).toBe(3);
+
+    await deleteRecipe(created.id, owner._id.toString());
+
+    await expect(getRecipeById(created.id)).rejects.toMatchObject({
+      message: "Recipe not found",
+      statusCode: 404,
+    });
+  });
+
+  it("blocks update and delete by non-owners", async () => {
+    const owner = await createUser("owner-guard@test.com", "Owner");
+    const other = await createUser("other-guard@test.com", "Other");
+
+    const created = await createRecipe(carbonaraInput(owner._id.toString()));
+
+    await expect(
+      updateRecipe({
+        recipeId: created.id,
+        userId: other._id.toString(),
+        title: "Should Not Work",
+      }),
+    ).rejects.toMatchObject({
+      message: "You can only edit your own recipes",
+      statusCode: 403,
+    });
+
+    await expect(
+      deleteRecipe(created.id, other._id.toString()),
+    ).rejects.toMatchObject({
+      message: "You can only delete your own recipes",
+      statusCode: 403,
+    });
+  });
+
+  it("supports search and skill-level filtering for recipe listing", async () => {
+    const owner = await createUser("filters@test.com");
+
+    await createRecipe({
+      ...carbonaraInput(owner._id.toString()),
+      title: "Spaghetti Carbonara",
+      skillLevel: "intermediate",
+    });
+
+    await createRecipe({
+      ...carbonaraInput(owner._id.toString()),
+      title: "Quick Salad",
+      description: "Simple salad",
+      ingredients: [{ foodItem: "Lettuce", amount: 1, unit: "head" }],
+      steps: ["Chop", "Serve"],
+      skillLevel: "beginner",
+      cookingTime: 5,
+    });
+
+    const search = await searchRecipes({ q: "carbonara" });
+    expect(search.recipes.length).toBeGreaterThan(0);
+    expect(search.recipes[0].title).toContain("Carbonara");
+
+    const filtered = await getRecipes({
+      createdBy: owner._id.toString(),
+      skillLevel: "beginner",
+    });
+    expect(filtered.recipes.length).toBe(1);
+    expect(filtered.recipes[0].title).toBe("Quick Salad");
+  });
+});
+

--- a/frontend/src/components/ui/Login/login.tsx
+++ b/frontend/src/components/ui/Login/login.tsx
@@ -69,6 +69,13 @@ export default function Login() {
 
   const loginContainerRef = useRef<HTMLDivElement>(null);
   const customizeContainerRef = useRef<HTMLDivElement>(null);
+  const timeoutRefs = useRef<Array<ReturnType<typeof setTimeout>>>([]);
+
+  const queueTimeout = (callback: () => void, delay: number) => {
+    const id = setTimeout(callback, delay);
+    timeoutRefs.current.push(id);
+    return id;
+  };
 
   useEffect(() => {
     const queryParameters = new URLSearchParams(window.location.search);
@@ -88,6 +95,15 @@ export default function Login() {
     }
   }, [navigate, isLogin, user, loading]);
 
+  useEffect(() => {
+    return () => {
+      for (const timeoutId of timeoutRefs.current) {
+        clearTimeout(timeoutId);
+      }
+      timeoutRefs.current = [];
+    };
+  }, []);
+
   const changeRegisterState = () => {
     if (isChangingState) return;
 
@@ -102,7 +118,7 @@ export default function Login() {
       `${window.location.pathname}?${params}`,
     );
 
-    setTimeout(() => {
+    queueTimeout(() => {
       setIsChangingState(false);
     }, 1000);
   };
@@ -112,23 +128,23 @@ export default function Login() {
       loginContainerRef.current.classList.add("login-fadeout");
     }
 
-    setTimeout(() => {
+    queueTimeout(() => {
       setShowCustomize(true);
     }, 800);
 
-    setTimeout(() => {
+    queueTimeout(() => {
       if (customizeContainerRef.current) {
         customizeContainerRef.current.classList.add("customize-slide");
       }
     }, 1000);
 
-    setTimeout(() => {
+    queueTimeout(() => {
       if (customizeContainerRef.current) {
         customizeContainerRef.current.classList.add("customize-expand");
       }
     }, 1800);
 
-    setTimeout(() => {
+    queueTimeout(() => {
       setIsCustomizeReady(true);
     }, 3000);
   };

--- a/frontend/tests/RecipeCrudFlow.test.tsx
+++ b/frontend/tests/RecipeCrudFlow.test.tsx
@@ -1,0 +1,271 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+const { mockUseUser, mockToastSuccess, mockToastError } = vi.hoisted(() => ({
+  mockUseUser: vi.fn(),
+  mockToastSuccess: vi.fn(),
+  mockToastError: vi.fn(),
+}));
+
+vi.mock("@/context/UserContext", () => ({
+  useUser: mockUseUser,
+}));
+
+vi.mock("react-hot-toast", () => ({
+  default: {
+    success: mockToastSuccess,
+    error: mockToastError,
+  },
+}));
+
+vi.mock("@/components/ui/RecipeContainer", () => ({
+  RecipeContainer: ({
+    recipes,
+    onEdit,
+    onDelete,
+  }: {
+    recipes: Array<{ id: string; title: string }>;
+    onEdit: (recipe: { id: string; title: string }) => void;
+    onDelete: (id: string) => void;
+  }) => (
+    <div>
+      {recipes.map((recipe) => (
+        <div key={recipe.id}>
+          <span>{recipe.title}</span>
+          <button onClick={() => onEdit(recipe)}>Edit {recipe.title}</button>
+          <button onClick={() => onDelete(recipe.id)}>Delete {recipe.title}</button>
+        </div>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock("@/components/ui/RecipeCreator", () => ({
+  default: ({
+    initialData,
+    onFinish,
+  }: {
+    initialData?: Record<string, unknown> | null;
+    onFinish: (data: Record<string, unknown>) => void;
+  }) => (
+    <div data-testid="recipe-creator">
+      {initialData ? (
+        <button
+          onClick={() =>
+            onFinish({
+              ...initialData,
+              title: "Authentic Spaghetti Carbonara",
+            })
+          }
+        >
+          Save Mock Recipe
+        </button>
+      ) : (
+        <button
+          onClick={() =>
+            onFinish({
+              id: "temp-id",
+              createdBy: "u1",
+              createdAt: new Date(),
+              updatedAt: new Date(),
+              title: "Spaghetti Carbonara",
+              description: "Classic Italian pasta dish",
+              prepingTime: 10,
+              cookingTime: 15,
+              servings: 2,
+              skillLevel: "intermediate",
+              dietaryTags: [],
+              ingredients: [
+                { foodItem: "Spaghetti", amount: 200, unit: "g" },
+                { foodItem: "Pancetta", amount: 100, unit: "g" },
+                { foodItem: "Eggs", amount: 2, unit: "unit" },
+                { foodItem: "Parmesan", amount: 50, unit: "g" },
+              ],
+              steps: [
+                "Boil pasta",
+                "Cook pancetta",
+                "Mix eggs and cheese",
+                "Combine all",
+              ],
+            })
+          }
+        >
+          Create Mock Recipe
+        </button>
+      )}
+    </div>
+  ),
+}));
+
+vi.mock("@/components/ui/RecipeView", () => ({
+  default: () => null,
+}));
+
+import { RecipeContent } from "@/components/ui/Dashboard/contents/RecipeForm";
+
+describe("Recipe CRUD flow (US.04)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseUser.mockReturnValue({
+      user: { id: "u1" },
+    });
+  });
+
+  it("creates, edits, and deletes a recipe from the collection with owner payloads", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = init?.method ?? "GET";
+
+      if (url.includes("/api/recipes?") && method === "GET") {
+        return {
+          ok: true,
+          json: async () => ({
+            data: {
+              recipes: [
+                {
+                  id: "seed-1",
+                  createdBy: "u1",
+                  title: "Seed Recipe",
+                  description: "seed",
+                  prepingTime: 5,
+                  cookingTime: 5,
+                  servings: 1,
+                  skillLevel: "beginner",
+                  dietaryTags: [],
+                  ingredients: [{ foodItem: "Water", amount: 1, unit: "cup" }],
+                  steps: ["Serve"],
+                },
+              ],
+            },
+          }),
+        } as Response;
+      }
+
+      if (url.endsWith("/api/recipes") && method === "POST") {
+        return {
+          ok: true,
+          json: async () => ({
+            data: {
+              id: "recipe-1",
+              createdBy: "u1",
+              title: "Spaghetti Carbonara",
+              description: "Classic Italian pasta dish",
+              prepingTime: 10,
+              cookingTime: 15,
+              servings: 2,
+              skillLevel: "intermediate",
+              dietaryTags: [],
+              ingredients: [{ foodItem: "Spaghetti", amount: 200, unit: "g" }],
+              steps: ["Boil pasta"],
+              createdAt: new Date().toISOString(),
+              updatedAt: new Date().toISOString(),
+            },
+          }),
+        } as Response;
+      }
+
+      if (url.includes("/api/recipes/recipe-1") && method === "PUT") {
+        return {
+          ok: true,
+          json: async () => ({
+            data: {
+              id: "recipe-1",
+              createdBy: "u1",
+              title: "Authentic Spaghetti Carbonara",
+              description: "Classic Italian pasta dish",
+              prepingTime: 10,
+              cookingTime: 15,
+              servings: 2,
+              skillLevel: "intermediate",
+              dietaryTags: [],
+              ingredients: [{ foodItem: "Spaghetti", amount: 200, unit: "g" }],
+              steps: ["Boil pasta"],
+              createdAt: new Date().toISOString(),
+              updatedAt: new Date().toISOString(),
+            },
+          }),
+        } as Response;
+      }
+
+      if (url.includes("/api/recipes/recipe-1") && method === "DELETE") {
+        return {
+          ok: true,
+          json: async () => ({ message: "Recipe deleted" }),
+        } as Response;
+      }
+
+      return {
+        ok: false,
+        json: async () => ({ message: "Unexpected request" }),
+      } as Response;
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<RecipeContent />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Seed Recipe")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("Create a new Recipe"));
+    fireEvent.click(screen.getByText("Create Mock Recipe"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Spaghetti Carbonara")).toBeInTheDocument();
+    });
+
+    const createCall = fetchMock.mock.calls.find(
+      ([url, init]) =>
+        String(url).endsWith("/api/recipes") && (init?.method ?? "GET") === "POST",
+    );
+    expect(createCall).toBeTruthy();
+    expect(JSON.parse(String(createCall?.[1]?.body))).toMatchObject({
+      userId: "u1",
+      title: "Spaghetti Carbonara",
+    });
+
+    fireEvent.click(screen.getByText("Edit Spaghetti Carbonara"));
+    fireEvent.click(screen.getByText("Save Mock Recipe"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Authentic Spaghetti Carbonara"),
+      ).toBeInTheDocument();
+    });
+
+    const updateCall = fetchMock.mock.calls.find(
+      ([url, init]) =>
+        String(url).includes("/api/recipes/recipe-1") &&
+        (init?.method ?? "GET") === "PUT",
+    );
+    expect(updateCall).toBeTruthy();
+    expect(JSON.parse(String(updateCall?.[1]?.body))).toMatchObject({
+      userId: "u1",
+      title: "Authentic Spaghetti Carbonara",
+    });
+
+    fireEvent.click(screen.getByText("Delete Authentic Spaghetti Carbonara"));
+    await waitFor(() => {
+      expect(screen.getByText("Confirm Delete")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Yes" }));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText("Authentic Spaghetti Carbonara"),
+      ).not.toBeInTheDocument();
+    });
+
+    const deleteCall = fetchMock.mock.calls.find(
+      ([url, init]) =>
+        String(url).includes("/api/recipes/recipe-1") &&
+        (init?.method ?? "GET") === "DELETE",
+    );
+    expect(deleteCall).toBeTruthy();
+    expect(JSON.parse(String(deleteCall?.[1]?.body))).toMatchObject({
+      userId: "u1",
+    });
+  });
+});
+

--- a/frontend/tests/SearchRecipesAndFilters.test.tsx
+++ b/frontend/tests/SearchRecipesAndFilters.test.tsx
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+import SearchContainer from "@/components/ui/Dashboard/SearchModal";
+
+type MockRecipe = {
+  id: string;
+  title: string;
+  description: string;
+  imageUrl?: string;
+  cookingTime: number;
+  skillLevel: "beginner" | "intermediate" | "advanced" | "expert";
+  ingredients?: Array<{ foodItem: string }>;
+};
+
+const allRecipes: MockRecipe[] = [
+  {
+    id: "1",
+    title: "Creamy Pasta Alfredo",
+    description: "Rich pasta with sauce",
+    cookingTime: 20,
+    skillLevel: "beginner",
+    ingredients: [{ foodItem: "pasta" }],
+  },
+  {
+    id: "2",
+    title: "Chicken Pasta Primavera",
+    description: "Chicken and pasta",
+    cookingTime: 35,
+    skillLevel: "intermediate",
+    ingredients: [{ foodItem: "chicken" }],
+  },
+  {
+    id: "3",
+    title: "Chicken Stir Fry",
+    description: "Quick chicken dinner",
+    cookingTime: 30,
+    skillLevel: "intermediate",
+    ingredients: [{ foodItem: "chicken" }],
+  },
+  {
+    id: "4",
+    title: "Beef Stew",
+    description: "Slow-cooked meal",
+    cookingTime: 90,
+    skillLevel: "advanced",
+    ingredients: [{ foodItem: "beef" }],
+  },
+];
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+function searchLocally(q: string) {
+  const needle = q.toLowerCase();
+  return allRecipes.filter((r) => {
+    const haystack = `${r.title} ${r.description} ${(r.ingredients ?? [])
+      .map((i) => i.foodItem)
+      .join(" ")}`.toLowerCase();
+    return haystack.includes(needle);
+  });
+}
+
+describe("Search + Filters UI (US.05 / US.06)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+        const url = new URL(String(input), "http://localhost");
+        const q = url.searchParams.get("q");
+        const recipes = q ? searchLocally(q) : allRecipes;
+
+        return {
+          ok: true,
+          json: async () => ({
+            data: {
+              recipes,
+            },
+          }),
+        } as Response;
+      });
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  it("supports keyword search, no results message, and clearing to full results", async () => {
+    render(<SearchContainer onClose={vi.fn()} />);
+
+    const searchInput = screen.getByPlaceholderText(/Search for recipes/i);
+    fireEvent.change(searchInput, { target: { value: "pasta" } });
+
+    await waitFor(() => {
+      expect(screen.getByText("Creamy Pasta Alfredo")).toBeInTheDocument();
+      expect(screen.getByText("Chicken Pasta Primavera")).toBeInTheDocument();
+      expect(screen.queryByText("Beef Stew")).not.toBeInTheDocument();
+    }, { timeout: 3000 });
+
+    fireEvent.change(searchInput, { target: { value: "zzzz-no-match" } });
+    await waitFor(() => {
+      expect(screen.getByText("No results found")).toBeInTheDocument();
+    }, { timeout: 3000 });
+
+    fireEvent.change(searchInput, { target: { value: "" } });
+    const suggestedButton = screen.getByRole("button", { name: "Suggested" });
+    fireEvent.click(suggestedButton);
+
+    await waitFor(() => {
+      expect(
+        fetchMock.mock.calls.some(([url]) =>
+          String(url).startsWith("/api/recipes?"),
+        ),
+      ).toBe(true);
+    }, { timeout: 3000 });
+  });
+
+  it("applies time + difficulty with AND logic when combined with search", async () => {
+    render(<SearchContainer onClose={vi.fn()} />);
+
+    fireEvent.change(screen.getByPlaceholderText(/Search for recipes/i), {
+      target: { value: "chicken" },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Chicken Pasta Primavera")).toBeInTheDocument();
+      expect(screen.getByText("Chicken Stir Fry")).toBeInTheDocument();
+    }, { timeout: 3000 });
+
+    const paramsBar = document.querySelector(".search-params");
+    expect(paramsBar).toBeTruthy();
+    const buttons = paramsBar?.querySelectorAll("button");
+    expect(buttons && buttons.length >= 2).toBe(true);
+    fireEvent.click(buttons![1]);
+
+    await waitFor(() => {
+      expect(screen.getByText("Skill Level")).toBeInTheDocument();
+      expect(screen.getByText("Cooking Time")).toBeInTheDocument();
+    }, { timeout: 3000 });
+
+    fireEvent.click(screen.getByRole("button", { name: "Intermediate" }));
+    fireEvent.click(screen.getByRole("button", { name: "15-30 mins" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Chicken Stir Fry")).toBeInTheDocument();
+      expect(screen.queryByText("Chicken Pasta Primavera")).not.toBeInTheDocument();
+    }, { timeout: 3000 });
+  });
+});


### PR DESCRIPTION
### Summary
This PR adds frontend and backend unit tests to cover the acceptance criteria for:

US.04 — Create, Edit, and Delete Recipes
US.05 — Search Recipes
US.06 — Filter Recipes
It also includes a small stability fix in Login to prevent unhandled async timer errors during test teardown.

The tests validate ownership constraints, persistence expectations, no-results behavior, and combined search/filter logic with AND semantics.

### Files Changed
`backend/tests/recipe.service.test.ts
`

- Adds backend unit tests for recipe CRUD lifecycle:
- create recipe and verify owner association
- update recipe and verify persistence
- delete recipe and verify removal
- non-owner edit/delete blocked with 403
- basic search/filter coverage in service layer

`backend/tests/recipe-search-filter.service.test.ts`

- Adds backend unit tests specifically for search/filter behavior:
- keyword search (case-insensitive, across title/description/ingredients)
- individual filters (max_time, difficulty alias, dietary tags)
- combined conditions with AND logic
- no-results case
- clear/unfiltered query restoring full dataset

` frontend/tests/RecipeCrudFlow.test.tsx
`
- Adds frontend unit test for end-to-end CRUD UI flow in RecipeForm:
- create recipe and verify list update
- edit recipe and verify updated list value
- delete recipe through confirmation modal
- verifies API payload includes userId ownership context

`frontend/tests/SearchRecipesAndFilters.test.tsx`

- Adds frontend unit tests for SearchModal:
- keyword search filtering and non-match hiding
- no-results messaging
- clearing flow restores full fetch path
- combined search + difficulty + time filters with AND logic

`frontend/src/components/ui/Login/login.tsx`

- Fixes timer cleanup to prevent unhandled window is not defined/teardown errors in Vitest:
- tracks timeouts via refs
- clears pending timeouts on unmount
- replaces direct setTimeout calls with managed helper

### Notes
Tests were run and passed for the newly added suites:
Backend:
tests/recipe.service.test.ts
tests/recipe-search-filter.service.test.ts
Frontend:
tests/RecipeCrudFlow.test.tsx
tests/SearchRecipesAndFilters.test.tsx
tests/Login.test.tsx (to verify timeout cleanup fix)

Cost-specific filtering is not currently implemented in backend query API; current test coverage aligns with implemented filter capabilities (time, difficulty, dietary tags, keyword search).