### PR TITLE
Story 11: Create Unit Tests for Duplicate Prevention

### DIFF
--- a/Sprints/ContributionLog/contribution-log-joey.md
+++ b/Sprints/ContributionLog/contribution-log-joey.md
@@ -25,6 +25,6 @@
 | 2026-03-15 | Unit Tests for Get Meal Plans | Write unit tests for fetching meal plan by ID, correct association with user, handling empty meal plan (no entries), handling non-existent meal plan ID. | 3h |
 | 2026-03-18 | Unit Tests for Get Meal Plans | Continuation of the above task | 3h |
 | 2026-03-22 | Unit Tests for Assign Recipe | Write unit tests for recipe assignment, duplicate prevention, ownership validation (user can only assign to their own meal plan), invalid recipe_id handling. | 3h |
-| 2026-03-27 | Unit Tests for Edit/Remove Meal Entry | Write unit tests for successful update, successful deletion, ownership validation on both, handling non-existent entry ID. | 3h |
+| 2026-03-27 | Unit Tests for: (1) Edit/Remove Meal Entry + (2) Duplicate Prevention | Write unit tests for (1) successful update, successful deletion, ownership validation on both, handling non-existent entry ID + (2) assigning the same recipe to two different day/meal slots (should fail on second), assigning different recipes to the same week (should succeed), updating an entry to use a recipe already assigned elsewhere in the same week (should fail). | 4.5h |
 
-**Total Time:** 12h
+**Total Time:** 13.5h

--- a/backend/src/services/meal-plan.service.ts
+++ b/backend/src/services/meal-plan.service.ts
@@ -251,6 +251,22 @@ export async function updateMealPlanEntry(
     throw error;
   }
 
+  const duplicateRecipe = await MealPlanEntry.findOne({
+    _id: { $ne: entryId },
+    mealPlanId: entry.mealPlanId,
+    recipeId,
+    mealType: { $ne: entry.mealType },
+  });
+
+  if (duplicateRecipe) {
+    const error: ApiError = new Error("This recipe is already assigned to ${duplicateRecipe.dayOfWeek}, ${duplicateRecipe.mealType} this week.");
+  error.statusCode = 409;
+  (error as ApiError & { details?: { existingMealType?: string } }).details = {
+    existingMealType: duplicateRecipe.mealType,
+  };
+  throw error;
+}
+  
   entry.recipeId = new mongoose.Types.ObjectId(recipeId);
   if (notes !== undefined) {
     entry.notes = notes;

--- a/backend/tests/meal-plan-entry.service.test.ts
+++ b/backend/tests/meal-plan-entry.service.test.ts
@@ -541,4 +541,192 @@ describe("MealPlanEntry service", () => {
     });
   });
 
+  it("fails with 409 when recipe A is assigned to Monday breakfast and then assigned again to Wednesday lunch in the same week", async () => {
+    
+    // Create a user
+    const user = await User.create({
+      email: "duplicate-recipe-a@example.com",
+      name: "Duplicate Recipe User",
+      passwordHash: "hashed-password",
+    });
+
+    // Create a meal plan for that user
+    const mealPlan = await MealPlan.create({
+      userId: user._id,
+      weekStartDate: new Date("2026-03-09T00:00:00.000Z"),
+    });
+
+    // Create a recipe for that user
+    const recipeA = await createTestRecipe(user._id, {
+      title: "Recipe A",
+    });
+
+    // First assignment should succeed
+    const firstResult = await createMealPlanEntry({
+      mealPlanId: mealPlan._id.toString(),
+      userId: user._id.toString(),
+      dayOfWeek: "Monday",
+      mealType: "breakfast",
+      recipeId: recipeA._id.toString(),
+      notes: "First assignment",
+    });
+
+    // Verify the first assignment was successful
+    expect(firstResult).toMatchObject({
+      mealPlanId: mealPlan._id.toString(),
+      dayOfWeek: "Monday",
+      mealType: "breakfast",
+      recipeId: recipeA._id.toString(),
+    });
+
+    // Second assignment of the same recipe in a different slot should fail
+    await expect(
+      createMealPlanEntry({
+        mealPlanId: mealPlan._id.toString(),
+        userId: user._id.toString(),
+        dayOfWeek: "Wednesday",
+        mealType: "lunch",
+        recipeId: recipeA._id.toString(),
+        notes: "Duplicate recipe in same week",
+      })
+    ).rejects.toMatchObject({
+      statusCode: 409,
+      message: "This recipe is already assigned to Monday, breakfast this week.",
+      details: {
+        existingMealType: "breakfast",
+      },
+    });
+
+    const entries = await MealPlanEntry.find({ mealPlanId: mealPlan._id }); // Check that only the first entry was created in database
+    expect(entries).toHaveLength(1); // Only the first entry should exist in database
+  });
+
+  it("succeeds when recipe A is assigned to Monday breakfast and recipe B is assigned to Wednesday lunch", async () => {
+    
+    // Create a user
+    const user = await User.create({
+      email: "different-recipes@example.com",
+      name: "Different Recipes User",
+      passwordHash: "hashed-password",
+    });
+
+    // Create a meal plan for that user
+    const mealPlan = await MealPlan.create({
+      userId: user._id,
+      weekStartDate: new Date("2026-03-09T00:00:00.000Z"),
+    });
+
+    // Create two recipes for that user
+    const recipeA = await createTestRecipe(user._id, {
+      title: "Recipe A",
+    });
+
+    const recipeB = await createTestRecipe(user._id, {
+      title: "Recipe B",
+    });
+
+    // Assign recipe A to Monday breakfast and recipe B to Wednesday lunch (both should succeed)
+    const mondayBreakfast = await createMealPlanEntry({
+      mealPlanId: mealPlan._id.toString(),
+      userId: user._id.toString(),
+      dayOfWeek: "Monday",
+      mealType: "breakfast",
+      recipeId: recipeA._id.toString(),
+      notes: "Monday breakfast",
+    });
+
+    const wednesdayLunch = await createMealPlanEntry({
+      mealPlanId: mealPlan._id.toString(),
+      userId: user._id.toString(),
+      dayOfWeek: "Wednesday",
+      mealType: "lunch",
+      recipeId: recipeB._id.toString(),
+      notes: "Wednesday lunch",
+    });
+
+    // Verify the assignments were successful
+    expect(mondayBreakfast).toMatchObject({
+      dayOfWeek: "Monday",
+      mealType: "breakfast",
+      recipeId: recipeA._id.toString(),
+    });
+
+    expect(wednesdayLunch).toMatchObject({
+      dayOfWeek: "Wednesday",
+      mealType: "lunch",
+      recipeId: recipeB._id.toString(),
+    });
+
+    // Check that both entries were created in database and have different recipe associations
+    const entries = await MealPlanEntry.find({ mealPlanId: mealPlan._id }).sort({
+      dayOfWeek: 1,
+      mealType: 1,
+    });
+    
+    expect(entries).toHaveLength(2); // Both entries should exist in database
+    expect(entries[0]?.recipeId.toString()).not.toBe(entries[1]?.recipeId.toString()); // The two entries should be associated with different recipes
+  });
+
+  it("fails with 409 when updating an entry to use a recipe already assigned elsewhere in the same week", async () => {
+    
+    // Create a user
+    const user = await User.create({
+      email: "update-duplicate@example.com",
+      name: "Update Duplicate User",
+      passwordHash: "hashed-password",
+    });
+
+    // Create a meal plan for that user
+    const mealPlan = await MealPlan.create({
+      userId: user._id,
+      weekStartDate: new Date("2026-03-09T00:00:00.000Z"),
+    });
+
+    // Create two recipes for that user
+    const recipeA = await createTestRecipe(user._id, {
+      title: "Recipe A",
+    });
+
+    const recipeB = await createTestRecipe(user._id, {
+      title: "Recipe B",
+    });
+
+    // Assign recipe A to Monday breakfast and recipe B to Wednesday lunch
+    const mondayBreakfast = await MealPlanEntry.create({
+      mealPlanId: mealPlan._id,
+      dayOfWeek: "Monday",
+      mealType: "breakfast",
+      recipeId: recipeA._id,
+      notes: "Monday breakfast",
+    });
+
+    const wednesdayLunch = await MealPlanEntry.create({
+      mealPlanId: mealPlan._id,
+      dayOfWeek: "Wednesday",
+      mealType: "lunch",
+      recipeId: recipeB._id,
+      notes: "Wednesday lunch",
+    });
+
+    // Attempt to update Wednesday lunch to use recipe A (should fail with 409)
+    await expect(
+      updateMealPlanEntry({
+        entryId: wednesdayLunch._id.toString(),
+        userId: user._id.toString(),
+        recipeId: recipeA._id.toString(),
+        notes: "Attempt duplicate via update",
+      })
+    ).rejects.toMatchObject({
+      statusCode: 409,
+    });
+
+    const unchangedEntry = await MealPlanEntry.findById(wednesdayLunch._id); // Check that the entry was not updated in database
+    expect(unchangedEntry).not.toBeNull(); // Entry should still exist in database
+    expect(unchangedEntry?.recipeId.toString()).toBe(recipeB._id.toString()); // Entry should still be associated with recipe B
+    const originalEntry = await MealPlanEntry.findById(mondayBreakfast._id); // Check that the original entry for recipe A was not affected
+    expect(originalEntry?.recipeId.toString()).toBe(recipeA._id.toString()); // Original entry should still be associated with recipe A
+  });
+
+
+
 });


### PR DESCRIPTION
Implemented unit tests for:
- Assign recipe A to Monday breakfast, then attempt to assign recipe A to Wednesday lunch (error 409)
- Assign recipe A to Monday breakfast and recipe B to Wednesday lunch (both should succeed)
- Update an existing entry (via Edit API) to use a recipe already assigned elsewhere in the same week (error 409)

Files changed:
- backend/src/services/meal-plan.service.ts
- backend/src/services/meal-plan-entry.service.test.ts
- Sprints/ContributionLog/contribution-log-joey.md

Closes #158