### PR TITLE
Fix meal plan duplicate recipe check across full week

### DIFF
--- a/backend/src/services/meal-plan.service.ts
+++ b/backend/src/services/meal-plan.service.ts
@@ -181,15 +181,14 @@ export async function createMealPlanEntry(
     throw error;
   }
 
-  // Prevent the same recipe appearing more than once on the same day
+  // Prevent the same recipe appearing more than once in the same week
   const duplicateRecipe = await MealPlanEntry.findOne({
     mealPlanId,
     recipeId,
-    dayOfWeek,
   });
   if (duplicateRecipe) {
     const error: ApiError = new Error(
-      `This recipe is already assigned to ${duplicateRecipe.mealType} on ${duplicateRecipe.dayOfWeek}.`
+      `This recipe is already assigned to ${duplicateRecipe.dayOfWeek}, ${duplicateRecipe.mealType} this week.`
     );
     error.statusCode = 409;
     (error as ApiError & { details?: { existingDay?: string; existingMealType?: string } }).details = {


### PR DESCRIPTION
The duplicate recipe validation in createMealPlanEntry was scoped to the same dayOfWeek, allowing the same recipe to be assigned to multiple different days within the same week. Removed the dayOfWeek filter so the check spans the entire meal plan (week), and updated the error message format to match expected output.